### PR TITLE
Add unit and controller tests for LoginService, StudentService, StudentController, and EmailServiceImpl

### DIFF
--- a/backendservice/src/test/java/com/example/backendservice/EmailServiceImplTest.java
+++ b/backendservice/src/test/java/com/example/backendservice/EmailServiceImplTest.java
@@ -1,0 +1,75 @@
+package com.example.backendservice;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceImplTest {
+
+    @Mock
+    private JavaMailSender javaMailSender;
+
+    @InjectMocks
+    private EmailServiceImpl emailService;
+
+    private EmailDetails details;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(emailService, "sender", "noreply@example.com");
+
+        details = new EmailDetails();
+        details.setRecipient("recipient@example.com");
+        details.setMsgBody("Test message body");
+        details.setSubject("Test Subject");
+    }
+
+    // --- sendSimpleMail ---
+
+    @Test
+    void sendSimpleMail_success_returnsSuccessMessage() {
+        doNothing().when(javaMailSender).send(any(SimpleMailMessage.class));
+
+        String result = emailService.sendSimpleMail(details);
+
+        assertEquals("Mail Sent Successfully...", result);
+        verify(javaMailSender).send(any(SimpleMailMessage.class));
+    }
+
+    @Test
+    void sendSimpleMail_whenExceptionThrown_returnsErrorMessage() {
+        doThrow(new RuntimeException("SMTP error")).when(javaMailSender).send(any(SimpleMailMessage.class));
+
+        String result = emailService.sendSimpleMail(details);
+
+        assertEquals("Error while Sending Mail", result);
+    }
+
+    // --- sendMailWithAttachment ---
+
+    @Test
+    void sendMailWithAttachment_whenAttachmentFileDoesNotExist_returnsErrorMessage() {
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        details.setAttachment("/nonexistent/path/file.txt");
+
+        // MimeMessageHelper will throw when trying to add a non-existent file
+        String result = emailService.sendMailWithAttachment(details);
+
+        assertEquals("Error while sending mail!!!", result);
+    }
+}

--- a/backendservice/src/test/java/com/example/backendservice/LoginServiceTest.java
+++ b/backendservice/src/test/java/com/example/backendservice/LoginServiceTest.java
@@ -1,0 +1,206 @@
+package com.example.backendservice;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+    @Mock
+    private LoginRepository loginRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    @InjectMocks
+    private LoginService loginService;
+
+    private Login existingLogin;
+
+    @BeforeEach
+    void setUp() {
+        existingLogin = new Login();
+        existingLogin.setEmail("user@example.com");
+        existingLogin.setPassword("secret123");
+        existingLogin.setLocked(false);
+        existingLogin.setOtp(1234);
+    }
+
+    // --- newLogin ---
+
+    @Test
+    void newLogin_whenEmailAlreadyExists_returnsNull() {
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+
+        Login input = new Login();
+        input.setEmail("user@example.com");
+
+        Login result = loginService.newLogin(input);
+
+        assertNull(result);
+        verify(loginRepository, never()).save(any());
+    }
+
+    @Test
+    void newLogin_whenEmailIsNew_savesAndReturnsLogin() {
+        Login newLogin = new Login();
+        newLogin.setEmail("new@example.com");
+        newLogin.setPassword("pass");
+
+        when(loginRepository.findById("new@example.com")).thenReturn(Optional.empty());
+        when(loginRepository.save(newLogin)).thenReturn(newLogin);
+
+        Login result = loginService.newLogin(newLogin);
+
+        assertNotNull(result);
+        assertEquals("new@example.com", result.getEmail());
+        verify(loginRepository).save(newLogin);
+    }
+
+    // --- findbyemail ---
+
+    @Test
+    void findbyemail_withCorrectPasswordAndUnlocked_returnsPass() {
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+
+        Login input = new Login();
+        input.setEmail("user@example.com");
+        input.setPassword("secret123");
+
+        assertEquals("pass", loginService.findbyemail(input));
+    }
+
+    @Test
+    void findbyemail_withCorrectPasswordButLocked_returnsLockedMessage() {
+        existingLogin.setLocked(true);
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+
+        Login input = new Login();
+        input.setEmail("user@example.com");
+        input.setPassword("secret123");
+
+        assertEquals("Your account has been locked", loginService.findbyemail(input));
+    }
+
+    @Test
+    void findbyemail_withWrongPassword_returnsInvalid() {
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+
+        Login input = new Login();
+        input.setEmail("user@example.com");
+        input.setPassword("wrongPassword");
+
+        assertEquals("invalid", loginService.findbyemail(input));
+    }
+
+    @Test
+    void findbyemail_withNonExistentEmail_returnsUsernameDoesNotExist() {
+        when(loginRepository.findById("ghost@example.com")).thenReturn(Optional.empty());
+
+        Login input = new Login();
+        input.setEmail("ghost@example.com");
+        input.setPassword("any");
+
+        assertEquals("username doesn't exist", loginService.findbyemail(input));
+    }
+
+    // --- updatePassword ---
+
+    @Test
+    void updatePassword_whenUserExists_updatesAndReturnsSuccess() {
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+        when(loginRepository.save(existingLogin)).thenReturn(existingLogin);
+
+        Login input = new Login();
+        input.setEmail("user@example.com");
+        input.setPassword("newPassword");
+
+        String result = loginService.updatePassword(input);
+
+        assertEquals("Password updated", result);
+        assertEquals("newPassword", existingLogin.getPassword());
+        verify(loginRepository).save(existingLogin);
+    }
+
+    @Test
+    void updatePassword_whenUserDoesNotExist_returnsError() {
+        when(loginRepository.findById("ghost@example.com")).thenReturn(Optional.empty());
+
+        Login input = new Login();
+        input.setEmail("ghost@example.com");
+        input.setPassword("any");
+
+        assertEquals("Username doesn't exist", loginService.updatePassword(input));
+        verify(loginRepository, never()).save(any());
+    }
+
+    // --- generateOTP ---
+
+    @Test
+    void generateOTP_whenEmailExists_generatesOTPAndReturnsSuccess() {
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+        when(loginRepository.save(existingLogin)).thenReturn(existingLogin);
+
+        String result = loginService.generateOTP("user@example.com");
+
+        assertEquals("OTP generated successfully", result);
+        // OTP should be a 4-digit number in range [1000, 9999]
+        assertTrue(existingLogin.getOtp() >= 1000 && existingLogin.getOtp() <= 9999);
+        verify(loginRepository).save(existingLogin);
+    }
+
+    @Test
+    void generateOTP_whenEmailDoesNotExist_returnsInvalidEmail() {
+        when(loginRepository.findById("ghost@example.com")).thenReturn(Optional.empty());
+
+        String result = loginService.generateOTP("ghost@example.com");
+
+        assertEquals("Invalid Email Address", result);
+        verify(loginRepository, never()).save(any());
+    }
+
+    // --- validateOTP ---
+
+    @Test
+    void validateOTP_whenOTPMatches_returnsTrue() {
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+
+        Login input = new Login();
+        input.setEmail("user@example.com");
+        input.setOtp(1234);
+
+        assertTrue(loginService.validateOTP(input));
+    }
+
+    @Test
+    void validateOTP_whenOTPDoesNotMatch_returnsFalse() {
+        when(loginRepository.findById("user@example.com")).thenReturn(Optional.of(existingLogin));
+
+        Login input = new Login();
+        input.setEmail("user@example.com");
+        input.setOtp(9999);
+
+        assertFalse(loginService.validateOTP(input));
+    }
+
+    @Test
+    void validateOTP_whenEmailDoesNotExist_returnsFalse() {
+        when(loginRepository.findById("ghost@example.com")).thenReturn(Optional.empty());
+
+        Login input = new Login();
+        input.setEmail("ghost@example.com");
+        input.setOtp(1234);
+
+        assertFalse(loginService.validateOTP(input));
+    }
+}

--- a/backendservice/src/test/java/com/example/backendservice/StudentControllerTest.java
+++ b/backendservice/src/test/java/com/example/backendservice/StudentControllerTest.java
@@ -1,0 +1,85 @@
+package com.example.backendservice;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(StudentController.class)
+class StudentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private StudentService studentService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private Student student;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student();
+        student.setStudentId(1);
+        student.setName("Alice");
+        student.setEmail("alice@example.com");
+        student.setRollNumber(101);
+    }
+
+    // --- GET /hello ---
+
+    @Test
+    void hello_returnsHelloWorld() throws Exception {
+        mockMvc.perform(get("/hello"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello World"));
+    }
+
+    // --- POST /newstudent ---
+
+    @Test
+    void createStudent_returnsCreatedStudent() throws Exception {
+        when(studentService.newStudent(any(Student.class))).thenReturn(student);
+
+        mockMvc.perform(post("/newstudent")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(student)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(1))
+                .andExpect(jsonPath("$.name").value("Alice"))
+                .andExpect(jsonPath("$.email").value("alice@example.com"))
+                .andExpect(jsonPath("$.rollNumber").value(101));
+    }
+
+    // --- GET /getid ---
+
+    @Test
+    void fetchById_whenStudentExists_returnsStudent() throws Exception {
+        when(studentService.fetchbyid(1)).thenReturn(student);
+
+        mockMvc.perform(get("/getid").param("id", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.studentId").value(1))
+                .andExpect(jsonPath("$.name").value("Alice"));
+    }
+
+    @Test
+    void fetchById_whenStudentDoesNotExist_returnsNull() throws Exception {
+        when(studentService.fetchbyid(999)).thenReturn(null);
+
+        mockMvc.perform(get("/getid").param("id", "999"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(""));
+    }
+}

--- a/backendservice/src/test/java/com/example/backendservice/StudentServiceTest.java
+++ b/backendservice/src/test/java/com/example/backendservice/StudentServiceTest.java
@@ -1,0 +1,70 @@
+package com.example.backendservice;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StudentServiceTest {
+
+    @Mock
+    private StudentRepository studentRepository;
+
+    @InjectMocks
+    private StudentService studentService;
+
+    private Student student;
+
+    @BeforeEach
+    void setUp() {
+        student = new Student();
+        student.setStudentId(1);
+        student.setName("Alice");
+        student.setEmail("alice@example.com");
+        student.setRollNumber(101);
+    }
+
+    // --- newStudent ---
+
+    @Test
+    void newStudent_savesAndReturnsStudent() {
+        when(studentRepository.save(student)).thenReturn(student);
+
+        Student result = studentService.newStudent(student);
+
+        assertNotNull(result);
+        assertEquals("Alice", result.getName());
+        assertEquals("alice@example.com", result.getEmail());
+        verify(studentRepository).save(student);
+    }
+
+    // --- fetchbyid ---
+
+    @Test
+    void fetchbyid_whenStudentExists_returnsStudent() {
+        when(studentRepository.findById(1)).thenReturn(Optional.of(student));
+
+        Student result = studentService.fetchbyid(1);
+
+        assertNotNull(result);
+        assertEquals(1, result.getStudentId());
+        assertEquals("Alice", result.getName());
+    }
+
+    @Test
+    void fetchbyid_whenStudentDoesNotExist_returnsNull() {
+        when(studentRepository.findById(999)).thenReturn(Optional.empty());
+
+        Student result = studentService.fetchbyid(999);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
Introduces 4 new test classes covering the previously untested business
logic layer. LoginServiceTest covers all branches in authentication,
OTP generation/validation, and password update. StudentServiceTest
covers save and fetch-by-id (found and not-found). StudentControllerTest
uses MockMvc to verify all three REST endpoints. EmailServiceImplTest
validates the happy-path and error-path for simple mail sending.

https://claude.ai/code/session_01FZ7WNjBK5inbhGLH1Xe6UZ